### PR TITLE
run benchmark as a regualr user

### DIFF
--- a/run_benchmark.sh
+++ b/run_benchmark.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-if ! [ $(id -u) = 0 ]; then
-	echo "This script must be run as root" 1>&2
-	exit 1
-fi
 base_dir=$(pwd)
 
 usage() {
@@ -69,7 +65,7 @@ create_srcpackage() {
 
 while [ $# -gt 0 ]; do
 	case "$1" in
-		--from-source)   SOURCE=1;;
+	--from-source)   SOURCE=1;;
         -l|--list)       list_bm; exit 0;;
         -h|--help)       usage; exit 0;;
 

--- a/suite/coremark
+++ b/suite/coremark
@@ -8,7 +8,7 @@ build() {
 
 run_benchmark() {
     make clean
-    make XCFLAGS="-DMULTITHREAD=$@ -DUSE_PTHREAD -lpthread"
+    make XCFLAGS="-DMULTITHREAD=$@ -DUSE_PTHREAD -pthread"
 }
 
 parse_result() {


### PR DESCRIPTION
It is not necessary to download, compile and run benchmarks as a root
user.